### PR TITLE
Added background option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ Default value: `false`
 
 Set to `true` when using ImageMagick instead of GraphicsMagick.
 
+### options.background
+
+Type: `String`
+Possible values: `none` to keep transparency, `beige` to set beige background, `#888` for gray.
+
+Define background color (default is white), for example when converting SVG images to PNGs.
+See [gm background documentation](http://www.graphicsmagick.org/GraphicsMagick.html#details-background)
+
 
 ## More Examples
 ```js

--- a/index.js
+++ b/index.js
@@ -88,6 +88,10 @@ module.exports = function imageResizer(options) {
           gmfile = gmfile.unsharp(options.sharpen);
         }
 
+        if (options.background) {
+          gmfile = gmfile.background(options.background);
+        }
+
         callback(null, gmfile);
       }
 


### PR DESCRIPTION
Because whenever I've used SVG images as a source, it flattened the transparency into white.

Please check changes in README.md because I'm not native english speaker.