### PR TITLE
Only restrict size if numbers provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,9 +45,12 @@ module.exports = function imageResizer(_options) {
 
           // if upscale is not requested, restrict size
           if(!options.upscale){
-            // Math.min(undefined, 5) will return NaN, so it can stay undefined
-            options.width  = Math.min(options.width, size.width);
-            options.height = Math.min(options.height, size.height);
+            if (!isNaN(options.width)) {
+              options.width  = Math.min(options.width, size.width);
+            }
+            if (!isNaN(options.height)) {
+              options.height = Math.min(options.height, size.height);
+            }
           }
 
           // if one dimension is not set - we fill it proportionally


### PR DESCRIPTION
**Without** this PR, `upscale` must be set to true (whether required or not) if a percentage resize is to occur;

~~~javascript
imageResize({width: "40%", upscale: true}) // resizes to 40%
imageResize({width: "40%"}) // "resizes" to 100%
~~~

**With** this PR;
~~~javascript
imageResize({width: "40%"}) // "resizes" to 40%
~~~